### PR TITLE
Fix admin session retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=sqlite://./dev.db
+NEXTAUTH_SECRET=your-secret
+NEXTAUTH_URL=http://localhost:3000
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Environment variables
+
+Create a `.env.local` file and ensure the `NEXTAUTH_URL` value matches the origin used in the browser. For local development it usually is:
+
+```bash
+NEXTAUTH_URL=http://localhost:3000
+```
+
+If the URL does not match, admin API requests will respond with `401 Unauthorized` because the session cookie will not be sent correctly.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/src/lib/jwt-helper.ts
+++ b/src/lib/jwt-helper.ts
@@ -1,65 +1,17 @@
-import { cookies } from 'next/headers'
-
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
 export async function getSessionFromCookie() {
   try {
-    const cookieStore = cookies()
-    
-    // Intentar diferentes nombres de cookies que NextAuth puede usar
-    const possibleCookieNames = [
-      'next-auth.session-token',
-      '__Secure-next-auth.session-token', // Para HTTPS
-      'next-auth.csrf-token',
-      '__Secure-next-auth.csrf-token'
-    ]
-    
-    let sessionToken = null
-    let cookieName = null
-    
-    for (const name of possibleCookieNames) {
-      const cookie = cookieStore.get(name)
-      if (cookie) {
-        sessionToken = cookie
-        cookieName = name
-        break
-      }
-    }
-    
-    if (!sessionToken) {
-      console.log('❌ No session token found in cookies')
-      console.log('📊 Available cookies:', cookieStore.getAll().map(c => c.name))
+    const session = await getServerSession(authOptions)
+
+    if (!session) {
+      console.log('❌ No session found')
       return null
     }
 
-    console.log(`🔍 Found session token: ${cookieName}`)
-    
-    // Hacer una petición interna a la API de session de NextAuth
-    const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000"
-    const sessionResponse = await fetch(`${baseUrl}/api/auth/session`, {
-      headers: {
-        'Cookie': `${cookieName}=${sessionToken.value}`
-      },
-      cache: 'no-store' // Evitar cache para obtener datos frescos
-    })
-    
-    if (!sessionResponse.ok) {
-      console.log('❌ Session API returned error:', sessionResponse.status, sessionResponse.statusText)
-      return null
-    }
-    
-    const sessionData = await sessionResponse.json()
-    console.log('✅ Session data from API:', {
-      hasUser: !!sessionData?.user,
-      email: sessionData?.user?.email,
-      expires: sessionData?.expires
-    })
-    
-    if (!sessionData || !sessionData.user) {
-      console.log('❌ No user in session data')
-      return null
-    }
-    
-    return sessionData
-    
+    console.log('✅ Session obtained for:', session.user?.email)
+    return session
+
   } catch (error) {
     console.error('❌ Error getting session:', error)
     return null


### PR DESCRIPTION
## Summary
- simplify session lookup using `getServerSession`
- document environment variable requirement for `NEXTAUTH_URL`
- allow `.env.example` to be versioned
- provide example `.env` file

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502eb8ee4c832ebbbde8b919640251