### PR TITLE
Refactor admin routes to use shared auth

### DIFF
--- a/src/app/api/admin/dispositivos/route.ts
+++ b/src/app/api/admin/dispositivos/route.ts
@@ -1,102 +1,18 @@
 // src/app/api/admin/dispositivos/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { cookies } from 'next/headers'
+import { verifyAdminFromCookies } from '@/lib/admin-auth'
 
-// ✅ FUNCIÓN SIMPLE para verificar admin (igual que en users/route.ts)
-async function verifyAdminFromCookies() {
-  try {
-    console.log('🔍 Verifying admin from cookies...')
-    
-    const cookieStore = cookies()
-    
-    // Buscar cookie de sesión
-    const sessionCookie = cookieStore.get('next-auth.session-token') || 
-                         cookieStore.get('__Secure-next-auth.session-token')
-    
-    console.log('🔍 Session cookie found:', !!sessionCookie)
-    
-    if (!sessionCookie) {
-      console.log('❌ No session cookie found')
-      return { isValid: false, error: 'No hay cookie de sesión' }
-    }
-
-    // ✅ HACER petición interna al endpoint de NextAuth que SÍ funciona
-    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000'
-    
-    try {
-      const sessionResponse = await fetch(`${baseUrl}/api/auth/session`, {
-        headers: {
-          'Cookie': cookieStore.toString()
-        },
-        cache: 'no-store'
-      })
-
-      if (!sessionResponse.ok) {
-        console.log('❌ Session API failed:', sessionResponse.status)
-        return { isValid: false, error: 'No se pudo verificar sesión' }
-      }
-
-      const sessionData = await sessionResponse.json()
-      console.log('✅ Session data from API:', {
-        hasUser: !!sessionData?.user,
-        email: sessionData?.user?.email,
-        accessType: sessionData?.user?.accessType
-      })
-
-      if (!sessionData?.user?.email) {
-        console.log('❌ No user in session')
-        return { isValid: false, error: 'No hay usuario en la sesión' }
-      }
-
-      // Verificar que es admin desde la sesión directamente
-      const userAccessType = sessionData.user.accessType
-      const userEmail = sessionData.user.email
-      
-      console.log('🔍 Checking admin status:', { email: userEmail, accessType: userAccessType })
-
-      // ✅ VERIFICACIÓN FLEXIBLE desde la sesión
-      const isAdmin = userAccessType === 'ADMIN' || 
-                     userAccessType === 'admin' || 
-                     userEmail === 'test@salvavidas.com'
-
-      if (!isAdmin) {
-        console.log(`❌ User ${userEmail} is not admin (accessType: ${userAccessType})`)
-        return { isValid: false, error: 'Acceso denegado - no es admin' }
-      }
-
-      console.log(`✅ Admin access verified for: ${userEmail}`)
-      return { 
-        isValid: true, 
-        user: {
-          email: userEmail,
-          accessType: userAccessType
-        }
-      }
-
-    } catch (fetchError) {
-      console.error('❌ Error fetching session:', fetchError)
-      return { isValid: false, error: 'Error al verificar sesión' }
-    }
-
-  } catch (error) {
-    console.error('❌ Error in verifyAdminFromCookies:', error)
-    return { isValid: false, error: 'Error interno de verificación' }
-  }
-}
 
 export async function GET(request: NextRequest) {
   try {
     console.log('🔍 GET /api/admin/dispositivos - Loading dispositivos for admin')
     
     const adminCheck = await verifyAdminFromCookies()
-    
-    if (!adminCheck.isValid) {
-      console.log('❌ Admin access denied for dispositivos:', adminCheck.error)
-      return NextResponse.json({ 
-        error: adminCheck.error || 'Acceso denegado',
-        debug: 'Admin verification failed for dispositivos'
-      }, { status: 401 })
+
+    if (!adminCheck.isAdmin) {
+      console.log('❌ Admin access denied for dispositivos')
+      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
     }
 
     console.log(`✅ Admin access verified for dispositivos: ${adminCheck.user?.email}`)

--- a/src/app/api/admin/empresas/route.ts
+++ b/src/app/api/admin/empresas/route.ts
@@ -1,102 +1,18 @@
 // src/app/api/admin/empresas/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { cookies } from 'next/headers'
+import { verifyAdminFromCookies } from '@/lib/admin-auth'
 
-// ✅ FUNCIÓN SIMPLE para verificar admin (igual que en users/route.ts)
-async function verifyAdminFromCookies() {
-  try {
-    console.log('🔍 Verifying admin from cookies...')
-    
-    const cookieStore = cookies()
-    
-    // Buscar cookie de sesión
-    const sessionCookie = cookieStore.get('next-auth.session-token') || 
-                         cookieStore.get('__Secure-next-auth.session-token')
-    
-    console.log('🔍 Session cookie found:', !!sessionCookie)
-    
-    if (!sessionCookie) {
-      console.log('❌ No session cookie found')
-      return { isValid: false, error: 'No hay cookie de sesión' }
-    }
-
-    // ✅ HACER petición interna al endpoint de NextAuth que SÍ funciona
-    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000'
-    
-    try {
-      const sessionResponse = await fetch(`${baseUrl}/api/auth/session`, {
-        headers: {
-          'Cookie': cookieStore.toString()
-        },
-        cache: 'no-store'
-      })
-
-      if (!sessionResponse.ok) {
-        console.log('❌ Session API failed:', sessionResponse.status)
-        return { isValid: false, error: 'No se pudo verificar sesión' }
-      }
-
-      const sessionData = await sessionResponse.json()
-      console.log('✅ Session data from API:', {
-        hasUser: !!sessionData?.user,
-        email: sessionData?.user?.email,
-        accessType: sessionData?.user?.accessType
-      })
-
-      if (!sessionData?.user?.email) {
-        console.log('❌ No user in session')
-        return { isValid: false, error: 'No hay usuario en la sesión' }
-      }
-
-      // Verificar que es admin desde la sesión directamente
-      const userAccessType = sessionData.user.accessType
-      const userEmail = sessionData.user.email
-      
-      console.log('🔍 Checking admin status:', { email: userEmail, accessType: userAccessType })
-
-      // ✅ VERIFICACIÓN FLEXIBLE desde la sesión
-      const isAdmin = userAccessType === 'ADMIN' || 
-                     userAccessType === 'admin' || 
-                     userEmail === 'test@salvavidas.com'
-
-      if (!isAdmin) {
-        console.log(`❌ User ${userEmail} is not admin (accessType: ${userAccessType})`)
-        return { isValid: false, error: 'Acceso denegado - no es admin' }
-      }
-
-      console.log(`✅ Admin access verified for: ${userEmail}`)
-      return { 
-        isValid: true, 
-        user: {
-          email: userEmail,
-          accessType: userAccessType
-        }
-      }
-
-    } catch (fetchError) {
-      console.error('❌ Error fetching session:', fetchError)
-      return { isValid: false, error: 'Error al verificar sesión' }
-    }
-
-  } catch (error) {
-    console.error('❌ Error in verifyAdminFromCookies:', error)
-    return { isValid: false, error: 'Error interno de verificación' }
-  }
-}
 
 export async function GET(request: NextRequest) {
   try {
     console.log('🔍 GET /api/admin/empresas - Loading empresas for admin')
     
     const adminCheck = await verifyAdminFromCookies()
-    
-    if (!adminCheck.isValid) {
-      console.log('❌ Admin access denied for empresas:', adminCheck.error)
-      return NextResponse.json({ 
-        error: adminCheck.error || 'Acceso denegado',
-        debug: 'Admin verification failed for empresas'
-      }, { status: 401 })
+
+    if (!adminCheck.isAdmin) {
+      console.log('❌ Admin access denied for empresas')
+      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
     }
 
     console.log(`✅ Admin access verified for empresas: ${adminCheck.user?.email}`)

--- a/src/app/api/admin/grupos/route.ts
+++ b/src/app/api/admin/grupos/route.ts
@@ -1,102 +1,18 @@
 // src/app/api/admin/grupos/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { cookies } from 'next/headers'
+import { verifyAdminFromCookies } from '@/lib/admin-auth'
 
-// ✅ FUNCIÓN SIMPLE para verificar admin (igual que en users/route.ts)
-async function verifyAdminFromCookies() {
-  try {
-    console.log('🔍 Verifying admin from cookies...')
-    
-    const cookieStore = cookies()
-    
-    // Buscar cookie de sesión
-    const sessionCookie = cookieStore.get('next-auth.session-token') || 
-                         cookieStore.get('__Secure-next-auth.session-token')
-    
-    console.log('🔍 Session cookie found:', !!sessionCookie)
-    
-    if (!sessionCookie) {
-      console.log('❌ No session cookie found')
-      return { isValid: false, error: 'No hay cookie de sesión' }
-    }
-
-    // ✅ HACER petición interna al endpoint de NextAuth que SÍ funciona
-    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000'
-    
-    try {
-      const sessionResponse = await fetch(`${baseUrl}/api/auth/session`, {
-        headers: {
-          'Cookie': cookieStore.toString()
-        },
-        cache: 'no-store'
-      })
-
-      if (!sessionResponse.ok) {
-        console.log('❌ Session API failed:', sessionResponse.status)
-        return { isValid: false, error: 'No se pudo verificar sesión' }
-      }
-
-      const sessionData = await sessionResponse.json()
-      console.log('✅ Session data from API:', {
-        hasUser: !!sessionData?.user,
-        email: sessionData?.user?.email,
-        accessType: sessionData?.user?.accessType
-      })
-
-      if (!sessionData?.user?.email) {
-        console.log('❌ No user in session')
-        return { isValid: false, error: 'No hay usuario en la sesión' }
-      }
-
-      // Verificar que es admin desde la sesión directamente
-      const userAccessType = sessionData.user.accessType
-      const userEmail = sessionData.user.email
-      
-      console.log('🔍 Checking admin status:', { email: userEmail, accessType: userAccessType })
-
-      // ✅ VERIFICACIÓN FLEXIBLE desde la sesión
-      const isAdmin = userAccessType === 'ADMIN' || 
-                     userAccessType === 'admin' || 
-                     userEmail === 'test@salvavidas.com'
-
-      if (!isAdmin) {
-        console.log(`❌ User ${userEmail} is not admin (accessType: ${userAccessType})`)
-        return { isValid: false, error: 'Acceso denegado - no es admin' }
-      }
-
-      console.log(`✅ Admin access verified for: ${userEmail}`)
-      return { 
-        isValid: true, 
-        user: {
-          email: userEmail,
-          accessType: userAccessType
-        }
-      }
-
-    } catch (fetchError) {
-      console.error('❌ Error fetching session:', fetchError)
-      return { isValid: false, error: 'Error al verificar sesión' }
-    }
-
-  } catch (error) {
-    console.error('❌ Error in verifyAdminFromCookies:', error)
-    return { isValid: false, error: 'Error interno de verificación' }
-  }
-}
 
 export async function GET(request: NextRequest) {
   try {
     console.log('🔍 GET /api/admin/grupos - Loading grupos for admin')
     
     const adminCheck = await verifyAdminFromCookies()
-    
-    if (!adminCheck.isValid) {
-      console.log('❌ Admin access denied for grupos:', adminCheck.error)
-      return NextResponse.json({ 
-        error: adminCheck.error || 'Acceso denegado',
-        debug: 'Admin verification failed for grupos'
-      }, { status: 401 })
+
+    if (!adminCheck.isAdmin) {
+      console.log('❌ Admin access denied for grupos')
+      return NextResponse.json({ error: 'Acceso denegado' }, { status: 403 })
     }
 
     console.log(`✅ Admin access verified for grupos: ${adminCheck.user?.email}`)


### PR DESCRIPTION
## Summary
- reuse `verifyAdminFromCookies` in admin dispositivos, empresas and grupos routes
- remove duplicated local implementations

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685572875048832eac939861fc659af0